### PR TITLE
Rewrite About section to be personal rather than job-focused

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,38 +62,40 @@
     <div class="about-grid">
       <div class="about-text">
         <p>
-          I'm a <strong>Systems Support Analyst</strong>
-          with a background in Information Systems. I blend technical IT expertise
-          with a genuine interest in software development.
+          I spend a lot of time building things — side projects, game prototypes
+          in <strong>Godot</strong>, scripts that solve some problem I couldn't stop
+          thinking about. Making stuff is how I think.
         </p>
         <p>
-          I enjoy working across the full range — from keeping city infrastructure
-          running to building projects in <strong>Godot</strong>, writing scripts in
-          <strong>Python</strong>, and experimenting with cloud platforms.
+          Games are a big part of my life, both as a player and a maker. My tastes
+          run wide: story-driven games, boomer shooters, and the kind of indie titles
+          that do something you've never quite seen before. <strong>Hollow Knight</strong>
+          is my favorite game, and I think about it more than I probably should.
         </p>
         <p>
-          When I'm not at a keyboard for work, I'm usually at one for fun — exploring
-          indie games, tinkering on side projects, and picking up whatever's caught
-          my curiosity lately.
+          I'm driven by curiosity — I'll fall deep into a subject, pull it apart,
+          and come out the other side with a better understanding of how things work.
+          That's true whether it's a game mechanic, a new tool, or something I
+          had no business learning at 2am.
         </p>
       </div>
 
       <div class="about-sidebar">
         <div class="info-row">
-          <span class="info-label">Role</span>
-          <span class="info-value">Systems Support Analyst</span>
+          <span class="info-label">Based in</span>
+          <span class="info-value">Henderson, NV</span>
         </div>
         <div class="info-row">
-          <span class="info-label">Employer</span>
-          <span class="info-value">City of Henderson</span>
+          <span class="info-label">Currently into</span>
+          <span class="info-value">Godot, Python, cloud stuff</span>
         </div>
         <div class="info-row">
-          <span class="info-label">School</span>
-          <span class="info-value">University of Nevada, Reno</span>
+          <span class="info-label">Fav game</span>
+          <span class="info-value">Hollow Knight</span>
         </div>
         <div class="info-row">
-          <span class="info-label">Side Work</span>
-          <span class="info-value">Game dev &amp; personal projects</span>
+          <span class="info-label">Plays</span>
+          <span class="info-value">Story games, boomer shooters, indie</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Replace job-title-centric bio with paragraphs about building things, games (Hollow Knight, boomer shooters, story games), and curiosity. Update sidebar to show location, current interests, and favorite game instead of employer and role.